### PR TITLE
fix: broken link to rn dependencies

### DIFF
--- a/content/docs/react-native-sdk/getting-started/quickstart-okto-react-native/prerequisites.mdx
+++ b/content/docs/react-native-sdk/getting-started/quickstart-okto-react-native/prerequisites.mdx
@@ -7,7 +7,7 @@ import { Callout } from 'fumadocs-ui/components/callout';
 ### Setup and Configuration
 
 1. **Dependencies**
-   - For a detailed list of required dependencies, refer to our [`package.json`](https://github.com/okto-hq/okto-sdk-react-native-template-app/blob/main/package.json).
+   - For a detailed list of required dependencies, refer to our [`package.json`](https://github.com/okto-hq/okto-sdk-react-native-starter-repo/blob/main/package.json).
 
 2. **Okto API Key**
    - Obtain your API Key from the [Okto Dashboard](https://dashboard.okto.tech/).


### PR DESCRIPTION
- Fix broken link to RN dependencies on Prerequisites page