### PR TITLE
Fix : Broken link to Okto website in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Overview
 
-This repo houses Okto's [documentation](docs.okto.tech). More info below on how to run the website or submit PRs for new documentation, or website pages.
+This repo houses Okto's [documentation](https://docs.okto.tech/docs). More info below on how to run the website or submit PRs for new documentation, or website pages.
 
 ## Index
 


### PR DESCRIPTION
Fixed broken link to Okto website in documentation to ensure it points to the correct external URL (https://okto.tech).
